### PR TITLE
Update eslint-config-airbnb to 14.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dosomething/eslint-config",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Shared ESLint config for DoSomething.org projects.",
   "engines": {
     "npm": ">=3.0.0"
@@ -14,8 +14,8 @@
   "dependencies": {
     "eslint-config-airbnb": "^14.0.0",
     "eslint": "^3.15.0",
-    "eslint-plugin-jsx-a11y":"^4.0.0",
-    "eslint-plugin-import":"^2.2.0",
-    "eslint-plugin-react":"^6.9.0"
+    "eslint-plugin-jsx-a11y": "^4.0.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-react": "^6.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,17 +2,20 @@
   "name": "@dosomething/eslint-config",
   "version": "1.1.1",
   "description": "Shared ESLint config for DoSomething.org projects.",
+  "engines": {
+    "npm": ">=3.0.0"
+  },
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "David Furnes <dfurnes@dosomething.org>",
   "license": "MIT",
-  "peerDependencies": {
-    "eslint": "^2.2.0"
-  },
   "dependencies": {
-    "eslint-plugin-react": "^4.2.1",
-    "eslint-config-airbnb": "^6.1.0"
+    "eslint-config-airbnb": "^14.0.0",
+    "eslint": "^3.15.0",
+    "eslint-plugin-jsx-a11y":"^4.0.0",
+    "eslint-plugin-import":"^2.2.0",
+    "eslint-plugin-react":"^6.9.0"
   }
 }


### PR DESCRIPTION
#### What's this PR do?
- Updates eslint base [airbnb](https://github.com/airbnb/javascript) package to the most recent version as of today: 14.x
- Deprecates [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/) in favor of npm v3 flat structure, see ["Dealing with the deprecation of peerDependencies in NPM 3"](https://codingwithspike.wordpress.com/2016/01/21/dealing-with-the-deprecation-of-peerdependencies-in-npm-3/)
- Lists [`eslint-config-airbnb`](https://www.npmjs.com/package/eslint-config-airbnb) current peer dependencies as this package requirements
- Bumps package version to v2

#### How should this be manually tested?
- `npm install`
- 👁 @DFurnes, @weerd 

