### PR TITLE
Update from upstream & merge in overrides.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,36 @@
  */
 
 module.exports = {
-  "extends": "airbnb",
+  extends: 'airbnb',
 
   // We make a few tweaks to the stock rules:
-  "rules": {
-    "func-names": 0,
-    "id-length": [2, { "exceptions": ["i", "j", "k", "$"] }],
+  rules: {
+    // Do not require named functions.
+    'func-names': 0,
+
+    // Allow common iterator variable names.
+    'id-length': [2, { exceptions: ['i', 'j', 'k', '$'] }],
+
+    // Allow `console.log` so we can include logging
+    // in development builds. Warn on `debugger`.
+    'no-console': 'off',
+    'no-debugger': 'warn',
+
+    // Disable 'no-return-assign' because it makes common
+    // patterns like React's refs unwieldy.
+    'no-return-assign': 'off',
+
+    // Require space before "!" unary operator to conform
+    // to our PHP code style guide:
+    'space-unary-ops': ['error', {
+      words: true,
+      nonwords: false,
+      overrides: {
+        '!': true,
+      },
+    }],
+
+    // We prefer not to use the .jsx file extension.
+    'react/jsx-filename-extension': 'off',
   },
 };

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "author": "David Furnes <dfurnes@dosomething.org>",
   "license": "MIT",
   "dependencies": {
-    "eslint-config-airbnb": "^14.0.0",
+    "eslint-config-airbnb": "^15.0.1",
     "eslint": "^3.15.0",
-    "eslint-plugin-jsx-a11y": "^4.0.0",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-react": "^6.9.0"
+    "eslint-plugin-jsx-a11y": "^5.0.3",
+    "eslint-plugin-import": "^2.3.0",
+    "eslint-plugin-react": "^7.0.1"
   }
 }


### PR DESCRIPTION
This pull request pulls in the latest version of Airbnb's style rules, and the custom changes we had made in Phoenix Next – allowing `console.log` and `debugger` (since we strip that out in our build process), disabling `no-return-assign` to simplify React's `ref` syntax, and requiring a space before `!` like in our PHP style guide.