### PR TITLE
Updating to latest eslint-plugin-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "eslint-config-airbnb": "^15.0.1",
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
-    "eslint-plugin-react": "^7.0.1"
+    "eslint-plugin-react": "^7.1.0"
   }
 }


### PR DESCRIPTION
After the prior ESLint version bump and additional updates from the AirBnB linting configuration, we are seeing some odd warnings pop up, etc. 

```
can't resolve reference #/definitions/basicConfig from id #
can't resolve reference #/definitions/basicConfigOrBoolean from id #
can't resolve reference #/definitions/basicConfigOrBoolean from id #remote 
```
Seems like a bump in `eslint-plugin-react` might help with some of these issues.

*Note: realized after that the update to `7.1.0` was older and does not include the fix for the issue yet and using the `^` for the version would include updates to the package that would address the issue when the update is released. Closing for now.
